### PR TITLE
Artifactory port fix

### DIFF
--- a/files/compose/jenkins/docker-compose.yml
+++ b/files/compose/jenkins/docker-compose.yml
@@ -22,5 +22,6 @@ services:
     user: "${UID}:${GID}" # To fix file permissions
     ports:
     - "8081:8081"
+    - "8082:8082"
     volumes:
     - "/opt/docker-compose/jenkins/artifactory.config.import.yml:/opt/jfrog/artifactory/etc/artifactory.config.import.yml"


### PR DESCRIPTION
Added extra port, 8082, for the artifactory ui.

> To simplify things, the JFrog Platform uses only 2 external ports: 8081 for Artifactory REST APIs, 8082 for everything else (UI, and all other product’s APIs).

https://jfrog.com/knowledge-base/upgrading-jfrog-artifactory-to-jfrog-platform-qa/